### PR TITLE
Fix login state messages

### DIFF
--- a/api/qqmusic.py
+++ b/api/qqmusic.py
@@ -374,14 +374,14 @@ class QQMusicAPI:
                     return False, qr.data, error_msg
 
                 elif event == QRCodeLoginEvents.SCAN:
-                    logger.info("二维码已扫描，等待用户确认登录")
+                    logger.info("等待扫描二维码")
                     if callback:
-                        callback("scanned", "二维码已扫描，等待确认")
+                        callback("waiting_scan", "等待扫描二维码")
 
                 elif event == QRCodeLoginEvents.CONF:
-                    logger.info("用户正在确认登录")
+                    logger.info("已扫码未确认登录")
                     if callback:
-                        callback("waiting_confirm", "用户正在确认登录")
+                        callback("waiting_confirm", "已扫码未确认登录")
 
                 else:
                     logger.warning("出现未知状态")

--- a/ui/login_dialog.py
+++ b/ui/login_dialog.py
@@ -84,9 +84,9 @@ class LoginWorker(QThread):
             if event_type == "qr_generated":
                 # data 现在是二维码的字节数据
                 self.qr_generated.emit(data)
-            elif event_type == "scanned":
+            elif event_type == "waiting_scan":
                 self.status_update.emit(str(data))
-            elif event_type == "waiting":
+            elif event_type == "waiting_confirm":
                 self.status_update.emit(str(data))
             elif event_type == "login_success":
                 user_info = self.adapter.get_user_info()


### PR DESCRIPTION
## Summary
- send `waiting_confirm` callback when QR is scanned
- handle new `waiting_confirm` event in login dialog
- refine login messages per official API state descriptions

## Testing
- `python -m py_compile api/qqmusic.py ui/login_dialog.py`


------
https://chatgpt.com/codex/tasks/task_b_6847e2d7c7ac832fa5969306e1370fa8