### PR TITLE
Replace debug prints with logger

### DIFF
--- a/api/qqmusic.py
+++ b/api/qqmusic.py
@@ -17,7 +17,7 @@ try:
     QQMUSIC_API_AVAILABLE = True
 except ImportError:
     QQMUSIC_API_AVAILABLE = False
-    print("警告: qqmusic-api-python 未安装")
+    logger.warning("警告: qqmusic-api-python 未安装")
 
 from utils.logger import logger
 
@@ -117,8 +117,7 @@ class QQMusicAPI:
                 page=page,
                 num=limit
             )
-            with open("json/search_song_result.json", "w", encoding="utf-8") as f:
-                json.dump(result, f, indent=4, ensure_ascii=False)
+            logger.debug("search_song result: %s", result)
             return {
                 "code": 0,
                 "songs": result if isinstance(result, list) else [],
@@ -168,9 +167,9 @@ class QQMusicAPI:
             }
 
             file_type = quality_map.get(quality, song.SongFileType.MP3_128)
-            result = await song.get_song_urls([song_mid], file_type, credential=self.credential)
-            with open("json/song_url_result.json", "w", encoding="utf-8") as f:
-                json.dump(result, f, indent=4, ensure_ascii=False)
+            result = await song.get_song_urls(
+                [song_mid], file_type, credential=self.credential)
+            logger.debug("song_url result: %s", result)
 
             if isinstance(result, dict) and song_mid in result:
                 url = result[song_mid]
@@ -203,8 +202,7 @@ class QQMusicAPI:
                 page=page,
                 num=limit
             )
-            with open("json/search_album_result.json", "w", encoding="utf-8") as f:
-                json.dump(result, f, indent=4, ensure_ascii=False)
+            logger.debug("search_album result: %s", result)
             return {
                 "code": 0,
                 "albums": result if isinstance(result, list) else [],
@@ -225,8 +223,7 @@ class QQMusicAPI:
         """
         try:
             result = await album.get_song(album_mid, num=100, page=1)
-            with open("json/album_detail_result.json", "w", encoding="utf-8") as f:
-                json.dump(result, f, indent=4, ensure_ascii=False)
+            logger.debug("album_detail result: %s", result)
             return {
                 "code": 0,
                 "songs": result if isinstance(result, list) else [],
@@ -256,8 +253,7 @@ class QQMusicAPI:
                 page=page,
                 num=limit
             )
-            with open("json/search_playlist_result.json", "w", encoding="utf-8") as f:
-                json.dump(result, f, indent=4, ensure_ascii=False)
+            logger.debug("search_playlist result: %s", result)
             return {
                 "code": 0,
                 "playlists": result if isinstance(result, list) else [],
@@ -307,8 +303,7 @@ class QQMusicAPI:
         """
         try:
             result = await lyric.get_lyric(song_mid, trans=True, roma=True)
-            with open("json/lyric_result.json", "w", encoding="utf-8") as f:
-                json.dump(result, f, indent=4, ensure_ascii=False)
+            logger.debug("lyric result: %s", result)
             if isinstance(result, dict):
                 return {
                     "code": 0,

--- a/json_to_lrc.py
+++ b/json_to_lrc.py
@@ -3,6 +3,8 @@ import re
 
 import json
 
+from utils.logger import logger
+
 
 def ms_to_timestamp(ms):
     """将毫秒转换为LRC格式的时间戳 [mm:ss.sss]"""
@@ -40,7 +42,7 @@ def parse_json_to_lrc(json_file, output_dir="lrc_output"):
         # 从XML中提取LyricContent
         match = re.search(r'LyricContent="([^"]+)"', lyric_xml)
         if not match:
-            print(f"无法从XML中提取歌词内容: {json_file}")
+            logger.warning(f"无法从XML中提取歌词内容: {json_file}")
             return
 
         lyric_content = match.group(1).replace(
@@ -249,17 +251,17 @@ def parse_json_to_lrc(json_file, output_dir="lrc_output"):
                         continue
                 f.write(line_text + "\n")
 
-        print(f"成功转换: {output_file}")
+        logger.info(f"成功转换: {output_file}")
 
     except Exception as e:
-        print(f"处理文件时出错: {e}")
+        logger.error(f"处理文件时出错: {e}")
         import traceback
         traceback.print_exc()
 
 
 def main():
     json_files = "json\lyrics_parser_word_by_word_older.json"
-    print(f"处理文件: {json_files}")
+    logger.info(f"处理文件: {json_files}")
 
 
     parse_json_to_lrc(json_files)

--- a/tgbot/bot.py
+++ b/tgbot/bot.py
@@ -5,9 +5,11 @@ import sys
 import os
 from pathlib import Path
 
+from utils.logger import logger
+
 # 确保可以导入项目根目录的模块
 current_dir = Path(__file__).parent
-print(current_dir)
+logger.debug(current_dir)
 project_root = current_dir.parent
 sys.path.insert(0, str(project_root))
 
@@ -46,7 +48,7 @@ class QQMusicBot:
                     module.register(self.app)
 
     def run(self):
-        print("QQ音乐Telegram机器人启动中...")
+        logger.info("QQ音乐Telegram机器人启动中...")
         self.app.run_polling()
 
 

--- a/tgbot/callbacks/song_selection.py
+++ b/tgbot/callbacks/song_selection.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(project_root))
 from downloader.music_downloader import MusicDownloader
 from utils.config import config
 from utils.formatters import format_singers
+from utils.logger import logger
 
 # 初始化QQ音乐API和下载管理器
 qq_music_api = QQMusicAPI()
@@ -59,7 +60,7 @@ async def handle_song_selection(update: Update, context: ContextTypes.DEFAULT_TY
             filetype = config.DEFAULT_QUALITY
             cookie = config.QQMUSIC_COOKIE
         except Exception as e:
-            print(f"重新加载配置失败: {str(e)}")
+            logger.warning(f"重新加载配置失败: {e}")
             # 如果重新加载失败，使用当前内存中的配置
             filetype = config.DEFAULT_QUALITY
             cookie = config.QQMUSIC_COOKIE
@@ -105,7 +106,7 @@ async def handle_song_selection(update: Update, context: ContextTypes.DEFAULT_TY
         try:
             cover_path = await music_downloader.download_manager.download_album_cover(album_mid, temp_dir)
         except Exception as cover_error:
-            print(f"封面下载失败: {str(cover_error)}")
+            logger.warning(f"封面下载失败: {cover_error}")
             pass  # 如果封面下载失败，继续而不使用封面
 
         # 准备发送的音频信息
@@ -157,12 +158,12 @@ async def handle_song_selection(update: Update, context: ContextTypes.DEFAULT_TY
             import shutil
             shutil.rmtree(temp_dir, ignore_errors=True)
         except Exception as e:
-            print(f"清理临时目录失败: {str(e)}")
+            logger.warning(f"清理临时目录失败: {e}")
 
     except Exception as e:
         # 获取详细的错误信息
         error_details = traceback.format_exc()
-        print(f"处理歌曲时出错: {error_details}")
+        logger.error(f"处理歌曲时出错: {error_details}")
 
         # 向用户显示友好的错误信息，包含错误原因
         error_msg = f"❌ 处理歌曲时出错: {str(e)}\n请稍后重试或联系管理员。"

--- a/ui/login_dialog.py
+++ b/ui/login_dialog.py
@@ -14,6 +14,7 @@ from PyQt6.QtCore import QThread, pyqtSignal, Qt
 from PyQt6.QtGui import QPixmap, QFont
 
 from api.qqmusic import QQMusicAPI
+from utils.logger import logger
 
 
 class LoginWorker(QThread):
@@ -96,7 +97,7 @@ class LoginWorker(QThread):
             elif event_type == "error":
                 self.login_failed.emit(str(data))
         except Exception as e:
-            print(f"回调处理错误: {e}")
+            logger.error(f"回调处理错误: {e}")
             self.login_failed.emit(f"回调处理错误: {str(e)}")
 
     def _phone_login(self):
@@ -244,16 +245,16 @@ class QRLoginWidget(QWidget):
                                                   Qt.TransformationMode.SmoothTransformation)
                     self.qr_label.setPixmap(scaled_pixmap)
                     self.status_label.setText("请使用手机扫描二维码")
-                    print("二维码已从内存加载并显示")
+                    logger.debug("二维码已从内存加载并显示")
                 else:
                     self.status_label.setText("二维码加载失败")
-                    print("无法从字节数据加载二维码图片")
+                    logger.warning("无法从字节数据加载二维码图片")
             else:
                 self.status_label.setText("二维码数据为空")
-                print("二维码数据为空")
+                logger.warning("二维码数据为空")
         except Exception as e:
             self.status_label.setText(f"显示二维码时出错: {str(e)}")
-            print(f"显示二维码时出错: {e}")
+            logger.error(f"显示二维码时出错: {e}")
 
     def show_qr(self, qr_path: str):
         """显示二维码（兼容旧版本，从文件路径加载）"""
@@ -266,16 +267,16 @@ class QRLoginWidget(QWidget):
                                                   Qt.TransformationMode.SmoothTransformation)
                     self.qr_label.setPixmap(scaled_pixmap)
                     self.status_label.setText("请使用手机扫描二维码")
-                    print(f"二维码已显示: {qr_path}")
+                    logger.debug(f"二维码已显示: {qr_path}")
                 else:
                     self.status_label.setText("二维码加载失败")
-                    print(f"无法加载二维码图片: {qr_path}")
+                    logger.warning(f"无法加载二维码图片: {qr_path}")
             else:
                 self.status_label.setText("二维码文件不存在")
-                print(f"二维码文件不存在: {qr_path}")
+                logger.warning(f"二维码文件不存在: {qr_path}")
         except Exception as e:
             self.status_label.setText(f"显示二维码时出错: {str(e)}")
-            print(f"显示二维码时出错: {e}")
+            logger.error(f"显示二维码时出错: {e}")
 
     def on_login_success(self, user_info: dict):
         """登录成功"""
@@ -362,8 +363,8 @@ if __name__ == "__main__":
     dialog = LoginDialog(adapter)
 
     if dialog.exec() == QDialog.DialogCode.Accepted:
-        print("登录成功:", dialog.get_user_info())
+        logger.info("登录成功: %s", dialog.get_user_info())
     else:
-        print("登录取消")
+        logger.info("登录取消")
 
     sys.exit()

--- a/ui/mainui.py
+++ b/ui/mainui.py
@@ -16,6 +16,7 @@ from PyQt6.QtWidgets import (QComboBox, QFileDialog, QGridLayout,
 from api.qqmusic import QQMusicAPI
 from downloader.music_downloader import MusicDownloader
 from utils.formatters import clean_html_tags
+from utils.logger import logger
 
 
 class WorkerThread(QThread):
@@ -291,19 +292,19 @@ class WorkerThread(QThread):
         })
 
     def run(self):
-        print(f"Starting new thread for task: {self.task_type}")
+        logger.info(f"Starting new thread for task: {self.task_type}")
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         try:
             loop.run_until_complete(self.run_task())
         except Exception as e:
-            print(f"Error in thread: {e}")
+            logger.error(f"Error in thread: {e}")
             import traceback
             traceback.print_exc()
         finally:
             # 不要关闭事件循环，仅清理它
             loop.run_until_complete(loop.shutdown_asyncgens())
-        print(f"Thread completed for task: {self.task_type}")
+        logger.info(f"Thread completed for task: {self.task_type}")
 
 
 class QQMusicDownloaderGUI(QMainWindow):
@@ -1471,7 +1472,7 @@ class QQMusicDownloaderGUI(QMainWindow):
                         'download_path', str(Path.home() / "Downloads"))
                     self._saved_quality = config.get('quality', '320')
         except Exception as e:
-            print(f"加载配置文件失败: {e}")
+            logger.warning(f"加载配置文件失败: {e}")
 
     def save_config(self):
         """保存配置文件"""
@@ -1492,7 +1493,7 @@ class QQMusicDownloaderGUI(QMainWindow):
             with open(self.config_file, 'w', encoding='utf-8') as f:
                 json.dump(existing_config, f, ensure_ascii=False, indent=2)
         except Exception as e:
-            print(f"保存配置文件失败: {e}")
+            logger.warning(f"保存配置文件失败: {e}")
 
     async def search_song_for_download(self, song_name, singer_name):
         """搜索单首歌曲用于下载"""
@@ -1868,9 +1869,10 @@ class QQMusicDownloaderGUI(QMainWindow):
             try:
                 is_logged_in = await self.api.is_logged_in()
                 # 可以根据登录状态启用/禁用相关菜单项
-                print(f"登录状态: {'已登录' if is_logged_in else '未登录'}")
+                logger.info(
+                    f"登录状态: {'已登录' if is_logged_in else '未登录'}")
             except Exception as e:
-                print(f"检查登录状态时出错: {e}")
+                logger.warning(f"检查登录状态时出错: {e}")
                 is_logged_in = False
 
     def show_login_dialog(self):
@@ -1989,7 +1991,7 @@ class QQMusicDownloaderGUI(QMainWindow):
             with open(self.config_file, 'w', encoding='utf-8') as f:
                 json.dump(existing_config, f, ensure_ascii=False, indent=2)
         except Exception as e:
-            print(f"保存API设置失败: {e}")
+            logger.warning(f"保存API设置失败: {e}")
 
     def show_about(self):
         """显示关于对话框"""

--- a/utils/cookie2json.py
+++ b/utils/cookie2json.py
@@ -1,5 +1,7 @@
 import json
 
+from utils.logger import logger
+
 data_str = """RK=HcXILXlyQ3; ptcz=2e29b953ce55163edf676cef1baddcd65cbf529e15caf686c5dc44a70bd0a57f; pac_uid=0_DWpnW4Se1GMbM; _qimei_uuid42=18b020b291110018ed0cb79799bdcd1853a9da177b; _qimei_fingerprint=f85b38cc9f1388641316f92802c3da81; _qimei_h38=2db8665aed0cb79799bdcd180200000fe18b02; qq_domain_video_guid_verify=078f1094fb3d98f1; tvfe_boss_uuid=406c5c9d541131c6; pgv_pvid=6916008410; _qimei_q32=aba8d6cb7a8727616eee300ad1d760d3; _qimei_q36=2f8df2a3b15e109877e90a27300019018818; ts_uid=7953382399; fqm_pvqid=e44c8b21-1e15-4b99-9f5e-10ad3d2f04a1; suid=user_0_DWpnW4Se1GMbM; ETCI=3207b28b2b534b2ab473f097b638c0e8; omgid=0_DWpnW4Se1GMbM; ts_refer=678910.cc/; fqm_sessionid=85da44ba-9d2e-406f-a014-3a5a04008827; pgv_info=ssid=s8851706640; ts_last=y.qq.com/"""
 
 # 拆分并转换为字典
@@ -8,4 +10,4 @@ cookie_dict = dict(item.strip().split('=', 1) for item in data_str.split('; ') i
 # 输出为 JSON 字符串（格式化）
 json_output = json.dumps(cookie_dict, indent=4, ensure_ascii=False)
 
-print(json_output)
+logger.info(json_output)

--- a/utils/formatters.py
+++ b/utils/formatters.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 from urllib.parse import urlparse
 
 from utils.config import config
+from utils.logger import logger
 
 
 def format_singers(singers: List[Dict]) -> str:
@@ -155,7 +156,7 @@ def _parse_wbw_lyrics(lyric_str: str, lyric_type: str) -> list[tuple[int, str, s
         # 从XML中提取LyricContent
         match = re.search(r'LyricContent="([^"]+)"', lyric_str)
         if not match:
-            print(f"无法从XML中提取歌词内容: {lyric_str}")
+            logger.warning(f"无法从XML中提取歌词内容: {lyric_str}")
             return
 
         lyric_content = match.group(1).replace(

--- a/utils/network.py
+++ b/utils/network.py
@@ -3,6 +3,8 @@ from typing import Optional, Dict, Any
 import httpx
 import urllib3
 
+from utils.logger import logger
+
 
 class NetworkManager:
     """网络请求管理类"""
@@ -37,7 +39,7 @@ class NetworkManager:
         try:
             return self.client.get(url, **kwargs)
         except Exception as e:
-            print(f"请求失败: {str(e)}")
+            logger.error(f"请求失败: {e}")
             return None
 
     async def async_get(self, url: str, params: Optional[Dict] = None,
@@ -50,7 +52,7 @@ class NetworkManager:
                 return None
             return response.json()
         except Exception as e:
-            print(f"异步请求失败: {str(e)}")
+            logger.error(f"异步请求失败: {e}")
             return None
 
     async def async_get_text(self, url: str, params: Optional[Dict] = None,
@@ -63,7 +65,7 @@ class NetworkManager:
                 return None
             return response.text
         except Exception as e:
-            print(f"异步请求失败: {str(e)}")
+            logger.error(f"异步请求失败: {e}")
             return None
 
     async def async_post(self, url: str, data: Optional[Dict] = None,
@@ -76,7 +78,7 @@ class NetworkManager:
                 return None
             return response.json()
         except Exception as e:
-            print(f"异步请求失败: {str(e)}")
+            logger.error(f"异步请求失败: {e}")
             return None
 
     async def async_get_bytes(self, url: str, headers: Optional[Dict] = None) -> Optional[bytes]:
@@ -88,7 +90,7 @@ class NetworkManager:
                 return None
             return response.read()
         except Exception as e:
-            print(f"异步请求失败: {str(e)}")
+            logger.error(f"异步请求失败: {e}")
             return None
 
     def close_sync(self):


### PR DESCRIPTION
## Summary
- clean up QQMusic API and switch debug file dumps to logger.debug
- replace print statements with logging across modules
- use logger in cookie utility, formatters, network
- update CLI tools to log messages instead of printing

## Testing
- `python -m py_compile api/qqmusic.py tgbot/bot.py tgbot/callbacks/song_selection.py ui/login_dialog.py ui/mainui.py utils/cookie2json.py utils/formatters.py utils/network.py json_to_lrc.py`

------
https://chatgpt.com/codex/tasks/task_b_6847ead61cc0832f889f27c044a3f3e1